### PR TITLE
Fix issues starting kernel; enable x87 FPU before using; Other fixes

### DIFF
--- a/kernel/entry.asm
+++ b/kernel/entry.asm
@@ -1,0 +1,25 @@
+bits 32
+
+extern kmain
+
+section .text.startup
+
+entry:
+
+    ; Enable the x87 FPU (assumes one is present)
+    mov eax, cr4
+    or eax, 0x200
+    mov cr4, eax
+    fldcw [fpu_cw]
+
+    cld                        ; Required by the i386 System V ABI
+    call kmain                 ; Call kernel entry point
+
+; Infinite loop
+.hltloop:
+    hlt
+    jmp .hltloop
+
+fpu_cw:
+    dw 0x37f
+

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -2,8 +2,8 @@
 
 bool debug = true;
 
-void main() {
-    uint32_t main_addr = (uint32_t)&main;
+void kmain(void) {
+    uint32_t main_addr = (uint32_t)&kmain;
 
     term_init();
 

--- a/kernel/memory/paging/paging.c
+++ b/kernel/memory/paging/paging.c
@@ -75,7 +75,7 @@ void unmap_page(void *virt_addr) {
     if (!is_aligned(virt_addr))
         kpanic(0);
 
-    uint32_t phys_addr = get_physaddr(virt_addr);
+    uint32_t phys_addr = (uint32_t)get_physaddr(virt_addr);
 
     if (phys_addr != 0)
         pmm_free_frame(phys_addr);

--- a/kernel/util/panic.c
+++ b/kernel/util/panic.c
@@ -4,8 +4,7 @@ unsigned int eax, ebx, ecx, edx, esi, edi, ebp, esp, eip, eflags;
 unsigned int cr0, cr2, cr3, cr4;
 unsigned short cs, ds, ss;
 
-__attribute__((optimize("O0")));
-void save_regs() {
+__attribute__((optimize("O0"))) void save_regs() {
     asm volatile ("mov %%eax, %0" : "=r"(eax));
     asm volatile ("mov %%ebx, %0" : "=r"(ebx));
     asm volatile ("mov %%ecx, %0" : "=r"(ecx));
@@ -25,8 +24,7 @@ void save_regs() {
     asm volatile ("mov %%cr4, %0" : "=r"(cr4));
 }
 
-__attribute__((optimize("O0")));
-void kpanic(unsigned int eip) {
+__attribute__((optimize("O0"))) void kpanic(unsigned int eip) {
     save_regs();
 
     term_setcolor(VGA_COLOR_BLUE, VGA_COLOR_WHITE);

--- a/kernel/util/print.c
+++ b/kernel/util/print.c
@@ -145,7 +145,7 @@ void kprint(const char* format, ...) {
             case 'p': {
                 void *ptr = va_arg(args, void*);
 
-                num_to_str((unsigned long long)ptr, buffer, 16, 0);
+                num_to_str((unsigned long)ptr, buffer, 16, 0);
 
                 for (int j = 0; buffer[j] != '\0'; j++) {
                     term_putchar(buffer[j]);

--- a/linker.ld
+++ b/linker.ld
@@ -5,14 +5,21 @@ SECTIONS {
     . = 0x10000;
 
     .text : {
-        *(.text)
+        /* Ensure what is in .text.startup appears first */
+        *(.text.startup)
+        *(.text*)
     }
 
     .data : {
         *(.data)
     }
 
+    .rodata : {
+        *(.rodata*)
+    }
+
     .bss : {
+        *(COMMON)
         *(.bss)
     }
 


### PR DESCRIPTION
Changes made:

- Fix issues starting kernel, you can't write to `cs` register or a GPF will occur!
- Enable x87 FPU before using
- A20 check was buggy
- Stack should be set to even addresses for performance reasons
- Added file `entry.asm`. The code is placed into a new `.text.startup` section which the modified `linker.ld` script places first when outputting sections
- Other minor fixes